### PR TITLE
Updated README for SWiFT_20131108_PertMethodsGroup

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ from the NCAR Research Data Archive (RDA), and then run preprocessing utilities
   with 12 hours of spinup, using the GFS reanalysis dataset.
 - `SWiFT_20131108_PertMethodsGroup` - Simulations of idealized convective,
   neutral, and stable conditions extracted from the SWiFT canonical day between
-  2013-11-08 to 09. Subdirectories contain the input_sounding, namelist, tslist,
-  and output-control file (which reduces the number of variables that are stored
-  in the wrfout_d0* files).
+  2013-11-08 to 09, used to study different perturbation methods for turbulent
+  inflow generation.
+  Subdirectories contain the input_sounding, namelist, tslist, and output-control
+  file (which reduces the number of variables that are stored in the wrfout_d0*
+  files).
   - convective: 1800-2000 UTC, specified heat flux of 175 W/m^2

--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@ MMC project.
 Running `setup.sh`, will automatically download the initial/boundary conditions
 from the NCAR Research Data Archive (RDA), and then run preprocessing utilities
 `geogrid`, `ungrib`, and `metgrid`.
+
+`SWiFT_20131108_PertMethodsGroup` contains the input_sounding, namelist, tslist,
+and output-control file (which reduces the number of variables that are stored 
+in the wrfout_d0* files) for the convective case. 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,16 @@ MMC project.
 
 Running `setup.sh`, will automatically download the initial/boundary conditions
 from the NCAR Research Data Archive (RDA), and then run preprocessing utilities
-`geogrid`, `ungrib`, and `metgrid`.
+`geogrid`, `ungrib`, and `metgrid` for real WRF cases.
 
-`SWiFT_20131108_PertMethodsGroup` contains the input_sounding, namelist, tslist,
-and output-control file (which reduces the number of variables that are stored 
-in the wrfout_d0* files) for the convective case. 
+
+## Archived cases
+- `SWiFT_20131108_GFS` - Reference simulation of the SWiFT diurnal cycle from
+  2013-11-08 to 09, used in the coupling comparison study. 48 hrs were simulated
+  with 12 hours of spinup, using the GFS reanalysis dataset.
+- `SWiFT_20131108_PertMethodsGroup` - Simulations of idealized convective,
+  neutral, and stable conditions extracted from the SWiFT canonical day between
+  2013-11-08 to 09. Subdirectories contain the input_sounding, namelist, tslist,
+  and output-control file (which reduces the number of variables that are stored
+  in the wrfout_d0* files).
+  - convective: 1800-2000 UTC, specified heat flux of 175 W/m^2


### PR DESCRIPTION
Added a line for the SWiFT_20131108_PertMethodsGroup case. Let me know if you need me to go into more detail. I think once there are more than just the CBL case (if there are to be more) in this folder, then we can update with more useful information. Also, once there is some sort of report on the project, we can say this where the setups for that reports are stored.