### PR TITLE
Provide a mesoscale domain sanity-check namelist.

### DIFF
--- a/SWiFT_20131108_PertMethodsGroup/CBL_18Z-20Z/namelist.input_d01MesoCheck
+++ b/SWiFT_20131108_PertMethodsGroup/CBL_18Z-20Z/namelist.input_d01MesoCheck
@@ -1,0 +1,202 @@
+&time_control
+ run_days                  = 0,
+ run_hours                 = 6
+ run_minutes               = 0,
+ run_seconds               = 0,
+ start_year                = 2013,    2013,    
+ start_month               = 11,      11,      
+ start_day                 = 08,      08,     
+ start_hour                = 14,      16,    
+ start_minute              = 00,      00,   
+ start_second              = 00,      00,   
+ end_year                  = 2013,    2013, 
+ end_month                 = 11,      11,   
+ end_day                   = 08,      08,  
+ end_hour                  = 20,      20,  
+ end_minute                = 00,      00,  
+ end_second                = 00,      00,  
+ interval_seconds          = 10800
+ restart                   = .false.,
+ restart_interval_m        = 30 
+ io_form_history           = 2
+ io_form_restart           = 2
+ io_form_input             = 2
+ io_form_boundary          = 2
+ debug_level               = 0
+ history_interval_m        = 30,     10,   
+ frames_per_outfile        = 1,      1,  
+ override_restart_timers   = .true., 
+ write_hist_at_0h_rst      = .false.,
+ iofields_filename         = "mmc_spec_outfields.txt","mmc_spec_outfields.txt"
+ ignore_iofields_warning   = .true.,
+/
+
+&domains
+ time_step                 = 5,
+ time_step_fract_num       = 0, 
+ time_step_fract_den       = 1,
+ max_dom                   = 1,
+ s_we                      = 1,       1,
+ e_we                      = 48,     961,
+ s_sn                      = 1,       1,
+ e_sn                      = 48,     481,
+ s_vert                    = 1,       1,
+ e_vert                    = 88,      88,
+ vert_refine_method        = 0,       0,
+ dx                        = 240.0,  12.0   
+ dy                        = 240.0,  12.0     
+ grid_id                   = 1,       2,    
+ parent_id                 = 1,       1,    
+ i_parent_start            = 1,       216,
+ j_parent_start            = 1,       236,
+ parent_grid_ratio         = 1,       20,
+ parent_time_step_ratio    = 1,       50,
+ ztop                      = 1606.5122, 1606.5122 
+ hypsometric_opt           = 2,
+ feedback                  = 0,
+ smooth_option             = 0,
+ nproc_x                   = 4, !NCAR 
+ nproc_y                   = 4, !NCAR
+ !max_ts_locs               = 200,
+ !max_ts_level              = 88,
+ eta_levels   = 1.00000,  0.99727,  0.99440,  0.99139,
+                0.98823,  0.98492,  0.98144,  0.97779,
+                0.97396,  0.96994,  0.96573,  0.96130,
+                0.95666,  0.95179,  0.94669,  0.94133,
+                0.93571,  0.92981,  0.92362,  0.91714,
+                0.91033,  0.90320,  0.89572,  0.88787,
+                0.87965,  0.87102,  0.86198,  0.85250,
+                0.84257,  0.83216,  0.82124,  0.80981,
+                0.79782,  0.78527,  0.77212,  0.75834,
+                0.74391,  0.72881,  0.71320,  0.69763,
+                0.68211,  0.66664,  0.65120,  0.63581,
+                0.62047,  0.60516,  0.58990,  0.57469,
+                0.55952,  0.54438,  0.52930,  0.51425,
+                0.49925,  0.48429,  0.46937,  0.45449,
+                0.43966,  0.42487,  0.41012,  0.39541,
+                0.38074,  0.36611,  0.35153,  0.33699,
+                0.32248,  0.30802,  0.29360,  0.27922,
+                0.26488,  0.25058,  0.23633,  0.22211,
+                0.20793,  0.19379,  0.17969,  0.16564,
+                0.15162,  0.13764,  0.12370,  0.10980,
+                0.09594,  0.08212,  0.06833,  0.05459,
+                0.04088,  0.02722,  0.01359,  0.00000,
+ /
+
+&physics
+ mp_physics                = 0,       0,    
+ ra_lw_physics             = 0,       0,   
+ ra_sw_physics             = 0,       0,  
+ radt                      = 0,       0, 
+ sf_sfclay_physics         = 1,       1, 
+ sf_surface_physics        = 0,       0, 
+ bl_pbl_physics            = 1,       0, 
+ bldt                      = 0,       0, 
+ cu_physics                = 0,       0, 
+ cudt                      = 0,       0, 
+ isfflx                    = 1,
+ ifsnow                    = 0,
+ icloud                    = 0,
+ /
+
+&ideal
+ ideal_case                = 9    
+/
+
+&fdda
+/
+
+&dynamics
+ ! Cell Perturbation Method (CPM) - start
+ cell_pert                           = .false.,.false.,
+ cell_pert_2d                        = .false.,.false.,
+ cell_pert_2d_opt                    = 0,      0,
+ cell_pert_1d                        = .false.,.true.,
+ cell_tvcp                           = .false.,.false.,
+ cell_pert_amp                       = 0,      0.78,
+ pert_tsec                           = 0,      28.0,
+ cell_gppc                           = 0,      8,
+ cell_nbcx                           = 0,      3,
+ cell_nbcy                           = 0,      3,
+ cell_kbottom                        = 0,      2,
+ cell_ztop                           = 0,      900.0,
+ cell_zbottom                        = 0.0,    0.0,
+ cell_pert_RL                        = .false.,.false.,
+ cellRL_ztop                         = 0,      400.0,
+ cellRL_zbottom                      = 0,      250.0,
+ cellRL_pert_amp                     = 0,      0.5,
+ cell_pert_cbl                       = .false., .false.,
+ cell_cbl_zitop                      = 0.0,    1000.0,
+ cell_cbl_uowthst                    = 0.0,    1.93,
+ ! momentum perturbation extension
+ m_pert_uv                           = .false.,.false.,
+ m_pert_w                            = .false.,.false.,
+ m_pert_locx                         = 0,      -1,
+ m_pert_locy                         = 0,      0,
+ cell_width                          = 8,      8,
+ mom_pert_gps                        = 24,     24,
+ mom_pert_amp_uv                     = 1000.,  1000.,
+ mom_pert_amp_w                      = 1500.,  1500.,
+ mom_pert_kbot                       = 2,      0,
+ mom_pert_ktop                       = 22,     59,
+ ! Cell Perturbation Method (CPM) - end
+ rk_ord                    = 3,
+ diff_opt                  = 1,       2,   
+ km_opt                    = 4,       2,  
+ m_opt                     = 0,       1, 
+ sfs_opt                   = 0,       0, 
+ c_s                       = 0.25,    0.18, 
+ c_k                       = 0.10,    0.10,
+ tke_heat_flux             = 0.00,    0.0, 
+ tke_drag_coefficient      = 0.00,    0.00,
+ diff_6th_opt              = 0,       0,  
+ diff_6th_factor           = 0.12,    0.12,
+ base_temp                 = 290.
+ w_damping                 = 0,
+ damp_opt                  = 2,
+ zdamp                     = 400.0,   400.0,
+ dampcoef                  = 0.2,     0.2, 
+ khdif                     = 0,       0,  
+ kvdif                     = 0,       0,  
+ non_hydrostatic           = .true.,  .true., 
+ moist_adv_opt             = 1,       1,    
+ scalar_adv_opt            = 1,       1,   
+ tke_adv_opt               = 1,       1,  
+ h_mom_adv_order           = 5,       5, 
+ v_mom_adv_order           = 3,       3, 
+ h_sca_adv_order           = 5,       5, 
+ v_sca_adv_order           = 3,       3, 
+ mix_isotropic             = 1,       1, 
+ smdiv                     = 0.1,     0.1, 
+ emdiv                     = 0.01,    0.01, 
+ mix_full_fields           = .true.,  .true., 
+ non_hydrostatic           = .true.,  .true.,
+ pert_coriolis             = .true., .true.,
+ use_baseparam_fr_nml      = .true.,
+ spec_ideal                = .true.,
+ spec_hfx                  = 175.0,
+ spec_z0                   = 0.01,
+ spec_lat                  = 33.6,
+ /
+ 
+&bdy_control
+ spec_bdy_width            = 5,
+ spec_zone                 = 1,
+ relax_zone                = 4,
+ periodic_x                = .true., .false.,
+ symmetric_xs              = .false.,.false.,
+ symmetric_xe              = .false.,.false.,
+ open_xs                   = .false.,.false.,
+ open_xe                   = .false.,.false.,
+ periodic_y                = .true., .false.,
+ symmetric_ys              = .false.,.false.,
+ symmetric_ye              = .false.,.false.,
+ open_ys                   = .false.,.false.,
+ open_ye                   = .false.,.false.,
+ nested                    = .false., .true.,
+/
+
+ &namelist_quilt
+ nio_tasks_per_group       = 0,
+ nio_groups                = 1,
+ /


### PR DESCRIPTION
Adding a meso-only sanity check namelist so that folks can easily confirm mesoscale results and tslist functionality prior to running the more expensive nested simulations.  (This also serves any offline synthetic-method needs for high-output-frequency, mesoscale, time-evolving profiles, to be used in generating perturbed inflow-boundary plane timeseries for microscale domains.) 