### PR TITLE
ERA5 performs better w/out sst_update.

### DIFF
--- a/FINO_20100513to26/templates/namelist.input.template_ERA5
+++ b/FINO_20100513to26/templates/namelist.input.template_ERA5
@@ -109,7 +109,7 @@
  num_soil_layers           =  4,
  sf_urban_physics          =  0,  0,  0, 0, 0, 
  use_bathymetry            =  0,  0,  0, 0, 0,
- sst_update                =  1, 
+ sst_update                =  0, 
  sst_skin                  =  0,
  /
 


### PR DESCRIPTION
Double checked and ERA5 w/out sst_update outperformed ERA5 w/ sst_update for the time period of interest.